### PR TITLE
Fix inconsistent removal of trailing fwd slash across OS

### DIFF
--- a/R/dpinput_read.R
+++ b/R/dpinput_read.R
@@ -97,7 +97,7 @@ make_pinlink <- function(synced_input_i) {
 
     board_object <-  dpi::dp_connect(
       board_params = board_params, creds = creds,
-      board_subdir = file.path("dpinput/")
+      board_subdir = "dpinput/"
     )
 
     dpinput_i <- dpi::dp_get(


### PR DESCRIPTION
Why: Part of the fix to addresses amashadihossein/dpi#38 . Similar changes were done in all 3 core daapr pkgs: dpi, dpdeploy, dpbuild. For the fixes to address the underlying issue, all fixes will need to be incorporated.

What: Removed file.path calls when such calls impact AWS S3 path and instead explicitly passed the path with fwd slash as required by AWS S3 object path.

Background: file.path removes the trailing forward slash in a path in Windows OS, while it keeps it in Uinx. AWS S3 bucket paths require the trailing forward slash. As such, to make the behavior consistent across OS and inline with AWS S3 object path standards, we could remove the unnecessary file.path calls when the path is used to specify S3 object storage.