### PR TITLE
90 make targets default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dpbuild
 Title: A package to manage building of data products
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: 
     person(given = "Afshin",
            family = "Mashadi-Hossein",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dpbuild 0.2.1
+
+* Make targets default when using `dpcode_add()` as drake is superseded (#90)
+
 # dpbuild 0.2.0
 
 * Added back support for LabKey boards (#86). `pinsLabkey` is now required to work with LabKey boards

--- a/R/dp_init.R
+++ b/R/dp_init.R
@@ -83,7 +83,7 @@ dp_init <- function(project_path = fs::path_wd(),
                     creds_set_dried,
                     github_repo_url,
                     git_ignore = c(
-                      ".drake/", "_targets/", "*_files/", 
+                      ".drake/", "_targets/", "*_files/",
                       ".Rprofile", ".Renviron", ".Rhistory",
                       ".Rapp.history", ".Rproj.user", ".Rproj.user/",
                       ".DS_Store", "*.csv", "*.tsv",
@@ -325,7 +325,7 @@ fn_dry <- function(fn_called) {
 #' @title Hydrate a dried called function
 #' @description execute and returns the value of function call given its textual
 #'  (dried) representation
-#' @param fn_called a function called
+#' @param dried_fn a function called
 #' @return value of the called function given its textual representation
 #' @examples \dontrun{
 #' fn_hydrate(fn_dry(sum(log(1:10))))

--- a/R/dpcode_add.R
+++ b/R/dpcode_add.R
@@ -4,7 +4,7 @@
 #' @param use_targets T/F when TRUE, uses targets instead of drake (recommended)
 #' @return repo
 #' @export
-dpcode_add <- function(project_path, use_targets = F) {
+dpcode_add <- function(project_path, use_targets = T) {
   if (!fs::dir_exists(project_path)) {
     stop("project_path does not exist")
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -292,10 +292,9 @@ flname_xos_get <- function(fl, package = "dpbuild") {
 
 #' @title Check pins package compatibility
 #' @description Check pins package compatibility
-#' @param is_legacy A boolean variable to indicate if the pins version is legacy one
 #' @keywords internal
 check_pins_compatibility <- function(){
-  read_conf_file <- dpbuild:::dpconf_read(project_path = ".")
+  read_conf_file <- dpconf_read(project_path = ".")
 
   if ("is_legacy" %in% names(read_conf_file)) {
     is_legacy_dp <- read_conf_file$is_legacy

--- a/inst/README.Rmd
+++ b/inst/README.Rmd
@@ -40,10 +40,10 @@ params$board_params_set %>% knitr::kable(.)
 
 ### STEP 3: Build
 
-This by convention involves sourcing the main script `dp_make.R`
+This by convention involves running the main script `dp_make.R`
 
 ```{r build, eval=FALSE}
-source("./dp_make.R")
+targets::tar_make(script = "./dp_make.R")
 ```
 
 

--- a/inst/dp_journal.RMD
+++ b/inst/dp_journal.RMD
@@ -33,7 +33,7 @@ library(daapr)
 **Goal:** Ensure, we are in a properly set up `daap` project
 
 ```{r check_dp_init, results= TRUE }
-dpbuild:::is_valid_dp_repository(path = ".")
+dpbuild::is_valid_dp_repository(path = ".")
 ```
 
 ## Remote data platform credentials

--- a/inst/dp_journal_targets.RMD
+++ b/inst/dp_journal_targets.RMD
@@ -33,7 +33,7 @@ library(daapr)
 **Goal:** Ensure, we are in a properly set up `daap` project
 
 ```{r check_dp_init, results= TRUE }
-dpbuild:::is_valid_dp_repository(path = ".")
+dpbuild::is_valid_dp_repository(path = ".")
 ```
 
 ## Remote data platform credentials

--- a/man/check_pins_compatibility.Rd
+++ b/man/check_pins_compatibility.Rd
@@ -6,9 +6,6 @@
 \usage{
 check_pins_compatibility()
 }
-\arguments{
-\item{is_legacy}{A boolean variable to indicate if the pins version is legacy one}
-}
 \description{
 Check pins package compatibility
 }

--- a/man/dpcode_add.Rd
+++ b/man/dpcode_add.Rd
@@ -4,7 +4,7 @@
 \alias{dpcode_add}
 \title{Adds script templates}
 \usage{
-dpcode_add(project_path, use_targets = F)
+dpcode_add(project_path, use_targets = T)
 }
 \arguments{
 \item{project_path}{Path to the project}

--- a/man/fn_hydrate.Rd
+++ b/man/fn_hydrate.Rd
@@ -7,7 +7,7 @@
 fn_hydrate(dried_fn)
 }
 \arguments{
-\item{fn_called}{a function called}
+\item{dried_fn}{a function called}
 }
 \value{
 value of the called function given its textual representation


### PR DESCRIPTION
- Made package `targets` instead of `drake` to be the default in `dpcode_add` to encourage transitioning to `targets` as the next generation of workflow management tool
- Upped the minor version 